### PR TITLE
Add Poszo Next.js Security Headers Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ We've gathered some useful resources to get your started on your bug bounty jour
 - [Service Enumeration](https://github.com/ssstonebraker/Pentest-Service-Enumeration)
 - 
 
+- [Poszo Next.js Security Headers Starter](https://github.com/poszothebuilder/poszo-nextjs-security-headers) - Dependency-free Next.js security headers baseline with conservative defaults and a production verifier.
+
 ## CTF's
  *  [https://ctftime.org/](https://ctftime.org/) 
  *  [https://ctf.hackthebox.eu/ctfs](https://ctf.hackthebox.eu/ctfs)


### PR DESCRIPTION
Adds one free, MIT-licensed defensive resource to the Tools section.

The starter provides conservative Next.js security-header defaults, a dependency-free production verifier, CSP deployment guidance, and rollback-oriented checks. This is a self-submission maintained by Poszo LLC.

Resource: https://github.com/poszothebuilder/poszo-nextjs-security-headers